### PR TITLE
depurify function of SimpleCode

### DIFF
--- a/src/TensorNetworkCodes.jl
+++ b/src/TensorNetworkCodes.jl
@@ -17,7 +17,7 @@ export pauli_random_operator, pauli_rep_change, pauli_weight
 include("pauli_functions.jl")
 export num_qubits, verify
 export find_distance_logicals, find_pure_error, find_pure_errors, find_syndrome
-export gauge, permute, purify
+export gauge, permute, purify, depurify
 include("code_functions.jl")
 export edges, new_indices, nodes, num_nodes, physical_neighbours, set_coords!, shift_coords!
 export coords, edge_indices, edge_types, node_indices, node_types

--- a/src/code_functions.jl
+++ b/src/code_functions.jl
@@ -603,11 +603,11 @@ function depurify(code::SimpleCode, index::Int)
     logical_z = g[z_indices[1]]
     for i in x_indices[2:end]
         stabilizer = g[i]
-        g[i] = pauli_product(logical_x, stabilizer)
+        g[i] = pauli_product([logical_x, stabilizer])
     end
     for i in z_indices[2:end]
         stabilizer = g[i]
-        g[i] = pauli_product(logical_z, stabilizer)
+        g[i] = pauli_product([logical_z, stabilizer])
     end
 
     name = "$(index)th-Depurified $(code.name)"

--- a/src/code_functions.jl
+++ b/src/code_functions.jl
@@ -581,20 +581,22 @@ function depurify(code::SimpleCode, index::Int)
     k = Int(K / 2)
     n = num_qubits(code)
     # preconditions
-    (logical_qubit in 1:k) || error("logical qubit index out of bounds!")
-    (k != 0) || error("code is not [[n,0]] SimpleCode. Depurify function haven't been supported general case yet.")
+    (index in 1:n) || error("logical qubit index out of bounds!")
+    (k == 0) || error("code is not [[n,0]] SimpleCode. Depurify function haven't been supported general case yet.")
 
     x_indices = []
     z_indices = []
-    operators = g[:, index]
-    for (i, op) in enumerate(operators)
+    operators_on_index = [element[index] for element in g]
+    for (i, op) in enumerate(operators_on_index)
         if op in (1, 2)
             push!(x_indices, i)
+        end
         if op in (3, 2)
             push!(z_indices, i)
+        end
     end
-    if x_indices.length() == 0 || z_indices.length() == 0
-        error("code cannot be depurified. There is no X or Z operator in the column of the index.")
+    if length(x_indices) == 0 || length(z_indices) == 0
+        error("This code cannot be depurified. There is no X or Z operator in the column of the index.")
     end
 
     logical_x = g[x_indices[1]]
@@ -610,7 +612,8 @@ function depurify(code::SimpleCode, index::Int)
 
     name = "$(index)th-Depurified $(code.name)"
     physical_qubits = [i for i in 1:n if i != index]
-    new_stabilizers = g[:, physical_qubits]
+    left_stabilizer_index = [i for i in 1:length(g) if i != x_indices[1] && i != z_indices[1]]
+    new_stabilizers = [element[physical_qubits] for element in g[left_stabilizer_index]]
     new_logicals = [logical_x[physical_qubits], logical_z[physical_qubits]]
 
     return SimpleCode(name, new_stabilizers, new_logicals)

--- a/src/code_functions.jl
+++ b/src/code_functions.jl
@@ -568,7 +568,7 @@ end
 function depurify(code::SimpleCode, index::Int)
     """
         this function is depurification of SimpleCode.
-        It just supports depurification from [[n,0]] SimpleCode to [n[-1,1]] SimpleCode now.
+        It just supports depurification from [[n,0]] SimpleCode to [[n-1,1]] SimpleCode now.
         It should be extended to support more general depurification.
 
         Input:

--- a/test/code_functions.jl
+++ b/test/code_functions.jl
@@ -165,3 +165,25 @@ end
     @test length(new_code.logicals) == 0
     @test verify(new_code)
 end
+
+@testset "depurify" begin
+    code = purify(five_qubit_code())
+    code_copy = deepcopy(code)
+    new_code = depurify(code, 1)
+    # test code not modified
+    @test code.name == code_copy.name
+    @test code.stabilizers == code_copy.stabilizers
+    @test verify(code)
+    # test new_code modified as expected
+    @test new_code.name == "1th-Depurified $(code.name)"
+    @test num_qubits(new_code) == num_qubits(code) - 1
+    @test length(new_code.stabilizers) == num_qubits(new_code)-1
+    @test length(new_code.logicals) == 2
+    @test verify(new_code)
+    @test new_code.logicals == five_qubit_code().logicals
+    @test new_code.stabilizers == five_qubit_code().stabilizers
+    # test exceptions
+    @test_throws ErrorException depurify(code, 0)  # invalid logical qubit
+    @test_throws ErrorException depurify(code, 7)  # invalid logical qubit
+    @test_throws ErrorException depurify(five_qubit_code(), 1)  # depurifying with identity
+end


### PR DESCRIPTION
I created a "depurify" function that converts a SimpleCode of $[[n, 0]]$ state to a SimpleCode of $[[n-1, 1]]$ QEC code.
I also add its test. Please check it and let me know if you find a bug and have requests.

As I noted in a comment on the function, it should be extended to support more general depurification i.e. converting a $[[n, 0]]$ state to a $[[n-k, k]]$ QEC code, or converting a $[[n, k]]$ state to a $[[n-k', k+k']]$ QEC code.